### PR TITLE
search filters 2/3 working, third is not yet functional

### DIFF
--- a/app/Components/SearchFilterModal.js
+++ b/app/Components/SearchFilterModal.js
@@ -69,27 +69,27 @@ const SearchFilterModal = ({ blurb }) => {
         setSearchResults(searchResults.map((recipe, index) => {
             // we first check if recipe has already been hidden by filterCookTime
             if (recipe.visibility) {
-                if (recipe.cuisine='African') return {
+                if (recipe.cuisine==='African') return {
                     ...recipe,
                     ...recipe.visibility = searchFilter[4]
                 };
-                else if (recipe.cuisine='American') return {
+                else if (recipe.cuisine==='American') return {
                     ...recipe,
                     ...recipe.visibility = searchFilter[5]
                 };
-                else if (recipe.cuisine='Asian') return {
+                else if (recipe.cuisine==='Asian') return {
                     ...recipe,
                     ...recipe.visibility = searchFilter[6]
                 };
-                else if (recipe.cuisine='Italian') return {
+                else if (recipe.cuisine==='Italian') return {
                     ...recipe,
                     ...recipe.visibility = searchFilter[7]
                 };
-                else if (recipe.cuisine='Mexican') return {
+                else if (recipe.cuisine==='Mexican') return {
                     ...recipe,
                     ...recipe.visibility = searchFilter[8]
                 };
-                else if (recipe.cuisine='Spanish') return {
+                else if (recipe.cuisine==='Spanish') return {
                     ...recipe,
                     ...recipe.visibility = searchFilter[9]
                 };

--- a/app/Components/SearchFilterModal.js
+++ b/app/Components/SearchFilterModal.js
@@ -66,7 +66,7 @@ const SearchFilterModal = ({ blurb }) => {
     }
 
     function filterCuisine() {
-        setSearchResults(searchResults.map((recipe, index) => {
+        setSearchResults(searchResults.map((recipe) => {
             // we first check if recipe has already been hidden by filterCookTime
             if (recipe.visibility) {
                 if (recipe.cuisine==='African') return {
@@ -98,7 +98,7 @@ const SearchFilterModal = ({ blurb }) => {
     }
 
     function filterMealType() {
-        setSearchResults(searchResults.map((recipe, index) => {
+        setSearchResults(searchResults.map((recipe) => {
             // we first check if recipe has already been hidden by filterCookTime or filterCuisine
             if (recipe.visibility) {
                 if (recipe.category='Appetizer') return {


### PR DESCRIPTION
Category search filters errors when I switch the single equals (which does nothing) to either a .includes (as it should be) or a === (which would filter some but not all - not broken, just not working quite as it should). I am currently unable to find the source of this error but I will look more next weekend - wanted to get this in there for UAT at the very least.